### PR TITLE
Add photo upload component

### DIFF
--- a/front/src/components/PhotoUpload.vue
+++ b/front/src/components/PhotoUpload.vue
@@ -1,0 +1,88 @@
+<template>
+  <el-upload
+    ref="upload"
+    :action="uploadUrl"
+    :auto-upload="false"
+    :show-file-list="false"
+    :on-change="handlePreview"
+    :on-success="handleSuccess"
+    :file-list="files"
+    :data="postData"
+  >
+    <el-image :src="photoUrl" class="image-placeholder">
+      <div slot="error">
+        <i class="el-icon-picture-outline"></i>
+      </div>
+    </el-image>
+  </el-upload>
+</template>
+
+<script>
+export default {
+  name: 'PhotoUpload',
+  props: {
+    uploadUrl: {
+      default: null
+    },
+    postData: {
+      default: () => {
+        return {}
+      }
+    }
+  },
+  data () {
+    return {
+      photoUrl: this.postData.photo,
+      files: []
+    }
+  },
+  methods: {
+    submitImageForm () {
+      if (this.files.length === 0) {
+        this.sendPostDataOnly()
+      } else {
+        this.sendPhotoWithExtraPostData()
+      }
+    },
+    sendPostDataOnly () {
+      console.log('Enviar por post ')
+    },
+    sendPhotoWithExtraPostData () {
+      this.$refs.upload.submit()
+    },
+    handlePreview (file) {
+      this.getBase64(file.raw).then(res => {
+        this.photoUrl = res
+        this.$emit('preview', file)
+      })
+    },
+    handleSuccess () {
+      this.$emit('success')
+    },
+    getBase64 (file) {
+      return new Promise(function (resolve, reject) {
+        const reader = new FileReader()
+        let imgResult = ''
+        reader.readAsDataURL(file)
+        reader.onload = function () {
+          imgResult = reader.result
+        }
+        reader.onerror = function (error) {
+          reject(error)
+        }
+        reader.onloadend = function () {
+          resolve(imgResult)
+        }
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+.image-placeholder {
+  width: 85vw;
+  min-height: 250px;
+  line-height: 250px;
+}
+</style>


### PR DESCRIPTION
Backend requiere el envío conjunto de los datos de producto y la imagen.

Dado el poco tiempo, la solución rápida es utilizar la opción de enviar datos post del propio componente upload de Element.

Soy consciente que es terrible que un componente sea responsable de algo que no debería, pero desarrollar un componente de upload de cero se escapa a el plazo.

Lo correcto sería pedir a backend que el upload se haga en un endpoint diferenciado para que el componente de upload sólo se encargue de eso.